### PR TITLE
Added quay.io container badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # GitHub provider for Wharf
 
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/d2d48df2187247048cdf992e9a5f576d)](https://www.codacy.com/gh/iver-wharf/wharf-provider-github/dashboard?utm_source=github.com\&utm_medium=referral\&utm_content=iver-wharf/wharf-provider-github\&utm_campaign=Badge_Grade)
+[![Docker Repository on Quay](https://quay.io/repository/iver-wharf/wharf-provider-github/status "Docker Repository on Quay")](https://quay.io/repository/iver-wharf/wharf-provider-github)
 
 Import Wharf projects from GitHub repositories. Mainly focused on importing
 from github.com, importing from GitHub EE is not well tested.


### PR DESCRIPTION
This repo had a release, v1.1.1, so I built it and pushed it to quay.io. Here's the accompanying badge.

Related to https://github.com/iver-wharf/iver-wharf.github.io/issues/49

**Edit**: Marked as draft as the container badge was for the build process, not the container status