### PR TITLE
Expose bind adress as env var BIND_ADDRESS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 ## v1.2.0 (WIP)
 
+- Added environment var for setting bind address and port. (#14)
+
 - Added endpoint `GET /version` that returns an object of version data of the
   API itself. (#5)
 

--- a/main.go
+++ b/main.go
@@ -61,7 +61,12 @@ func main() {
 	r.GET("/import/github/version", getVersionHandler)
 	r.GET("/import/github/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
-	r.Run()
+	var bindAddress string
+	var bindAddressDefined bool
+	if bindAddress, bindAddressDefined = os.LookupEnv("BIND_ADDRESS"); !bindAddressDefined {
+		bindAddress = "0.0.0.0:8080"
+	}
+	_ = r.Run(bindAddress)
 }
 
 func runPingHandler(c *gin.Context) {

--- a/main.go
+++ b/main.go
@@ -61,12 +61,15 @@ func main() {
 	r.GET("/import/github/version", getVersionHandler)
 	r.GET("/import/github/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
-	var bindAddress string
-	var bindAddressDefined bool
-	if bindAddress, bindAddressDefined = os.LookupEnv("BIND_ADDRESS"); !bindAddressDefined {
-		bindAddress = "0.0.0.0:8080"
+	_ = r.Run(getBindAddress())
+}
+
+func getBindAddress() string {
+	bindAddress, isBindAddressDefined := os.LookupEnv("BIND_ADDRESS")
+	if !isBindAddressDefined || bindAddress == "" {
+		return "0.0.0.0:8080"
 	}
-	_ = r.Run(bindAddress)
+	return bindAddress
 }
 
 func runPingHandler(c *gin.Context) {


### PR DESCRIPTION
This allows setting the gin bind adress and port from an environment variable.