### PR TITLE
Updated golang & alpine Docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,12 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Changed version of wharf-api-client-go from 1.2.0 -> 1.3.0 (#10)
 
-- Changed version of Go runtime from 1.13 -> 1.16. (#10)
+- Changed version of Go runtime from 1.13 -> 1.16. (#5)
 
-- Changed version of alpine base Docker image from 3.13.4 -> 3.13.5. (#10)
+- Changed version of Docker base images:
+
+  - Alpine: 3.13.4 -> 3.14.0 (#10, #17)
+  - Golang: 1.13.4 -> 1.16.5 (#5, #17)
 
 - Changed from POST to PATCH calls for tokens & providers to eliminate entry
   duplication. (#10)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.4 AS build
+FROM golang:1.16.5 AS build
 WORKDIR /src
 ENV GO111MODULE=on
 RUN go get -u github.com/swaggo/swag/cmd/swag@v1.7.0
@@ -11,7 +11,7 @@ RUN deploy/update-version.sh version.yaml \
 		&& go get -t -d \
 		&& CGO_ENABLED=0 go build -o main
 
-FROM alpine:3.13.5 AS final
+FROM alpine:3.14.0 AS final
 RUN apk add --no-cache ca-certificates
 WORKDIR /app
 COPY --from=build /src/main ./


### PR DESCRIPTION
Go: v1.16.4 -> v1.16.5
Alpine: v3.13.5 -> v3.14.0
