### PR TITLE
Fixed make docker-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,8 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 - Changed to return IETF RFC-7807 compatible problem responses on failures
   instead of solely JSON-formatted strings. (#16)
 
-- Added Makefile to simplify building and developing the project locally. (#24)
+- Added Makefile to simplify building and developing the project locally.
+  (#24, #26)
 
 ## v2.0.0 (2021-07-12)
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ifneq "$(version)" "latest"
 endif
 
 docker-run:
-	docker run --rm -it harbor.dgc.local/tools/webhook-relay
+	docker run --rm -it quay.io/iver-wharf/wharf-provider-github:$(version)
 
 serve: swag
 	go run .


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

Updated the `make docker-run` command to run the correct Docker image.

## Motivation

Quite the embarassing misstake from my part over in #24. Probably as a result from my testing.
