### PR TITLE
Fixed Makefile docker build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   instead of solely JSON-formatted strings. (#16)
 
 - Added Makefile to simplify building and developing the project locally.
-  (#24, #26)
+  (#24, #26, #27)
 
 ## v2.0.0 (2021-07-12)
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build: swag
 	@echo "Built binary found at ./wharf-provider-github or ./wharf-provider-github.exe"
 
 docker:
-	@echo docker build . \
+	docker build . \
 		-t "quay.io/iver-wharf/wharf-provider-github:latest" \
 		-t "quay.io/iver-wharf/wharf-provider-github:$(version)" \
 		--build-arg BUILD_VERSION="$(version)" \


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- `make docker` only echo'd `docker build` and did not actually run it. Technically called a "boo boo" from my end.

It did go through review, so I mean, we're all to blame :)
