### PR TITLE
Updated to wharf-core v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,13 +39,16 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   from `github.com/iver-wharf/wharf-core/pkg/ginutil`. (#20)
 
 - Changed version of `github.com/iver-wharf/wharf-core` from pre release to
-  v1.0.0 (#19)
+  v1.1.0 (#19, #28)
 
 - Changed to return IETF RFC-7807 compatible problem responses on failures
   instead of solely JSON-formatted strings. (#16)
 
 - Added Makefile to simplify building and developing the project locally.
-  (#24, #26, #27)
+  (#24, #26, #27, #28)
+
+- Added logging and custom exit code when app fails to bind the IP address and
+  port. (#28)
 
 ## v2.0.0 (2021-07-12)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.16.5 AS build
 WORKDIR /src
 ENV GO111MODULE=on
 
-RUN go get -u github.com/swaggo/swag/cmd/swag@v1.7.0
+RUN go get -u github.com/swaggo/swag/cmd/swag@v1.7.1
 COPY go.mod go.sum ./
 RUN go mod download
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY . /src
 ARG BUILD_VERSION="local docker"
 ARG BUILD_GIT_COMMIT="HEAD"
 ARG BUILD_REF="0"
+ARG BUILD_DATE=""
 RUN deploy/update-version.sh version.yaml \
     && make swag \
     && CGO_ENABLED=0 go build -o main

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,6 @@ swag:
 	swag init --parseDependency --parseDepth 2
 
 deps:
-	cd .. && go get -u github.com/swaggo/swag
+	cd .. && go get -u github.com/swaggo/swag/cmd/swag@v1.7.1
 	go mod download
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/iver-wharf/wharf-provider-github
 go 1.16
 
 require (
-	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-gonic/gin v1.7.2
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
@@ -14,7 +13,7 @@ require (
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/iver-wharf/wharf-api-client-go v1.3.0
-	github.com/iver-wharf/wharf-core v1.0.0
+	github.com/iver-wharf/wharf-core v1.1.0
 	github.com/json-iterator/go v1.1.11 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -284,8 +284,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/iver-wharf/wharf-api-client-go v1.3.0 h1:UwWE/sh6gTQi9VE1oaTnGlilT5EoyuXvNj7XjOPgioU=
 github.com/iver-wharf/wharf-api-client-go v1.3.0/go.mod h1:IzhUU97bwsz3ZF1N4X8AM51Wca41HSVC5G56q3wDZDA=
-github.com/iver-wharf/wharf-core v1.0.0 h1:vBaGsGSMUDhTimIoaSvuX9yKKUssRxw17bbNlQ9JopY=
-github.com/iver-wharf/wharf-core v1.0.0/go.mod h1:dpYtdL52i17Aue7An6mJL9dICeulBDsGZO/PxZYHgrE=
+github.com/iver-wharf/wharf-core v1.1.0 h1:vdjW+A8p0GBBcd1sB3vKwpN44t0dBrYfpY+B6ebSMbI=
+github.com/iver-wharf/wharf-core v1.1.0/go.mod h1:dpYtdL52i17Aue7An6mJL9dICeulBDsGZO/PxZYHgrE=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=

--- a/internal/httputils/httpclient.go
+++ b/internal/httputils/httpclient.go
@@ -6,7 +6,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/iver-wharf/wharf-core/pkg/logger"
 )
+
+var log = logger.NewScoped("HTTPUTILS")
 
 // NewClientWithCerts creates a fresh net/http.Client populated with some
 // root CA certificates from file.
@@ -19,9 +23,9 @@ func NewClientWithCerts(localCertFile string) (*http.Client, error) {
 	// Get the SystemCertPool, continue with an empty pool on error
 	if rootCAs == nil {
 		rootCAs = x509.NewCertPool()
-		fmt.Println("using empty cert pool")
+		log.Debug().Message("Using empty cert pool.")
 	} else {
-		fmt.Println("using system cert pool")
+		log.Debug().Message("Using system's cert pool.")
 	}
 
 	// Read in the cert file
@@ -30,11 +34,11 @@ func NewClientWithCerts(localCertFile string) (*http.Client, error) {
 		return nil, fmt.Errorf("failed to append %q to RootCAs: %v", localCertFile, err)
 	}
 
-	fmt.Printf("loaded certs from %s\n", localCertFile)
+	log.Debug().WithString("file", localCertFile).Message("Loaded certs.")
 
 	// Append our cert to the system pool
 	if ok := rootCAs.AppendCertsFromPEM(certs); !ok {
-		fmt.Println("no certs appended, using system certs only")
+		log.Debug().Message("No certs appended, using system certs only.")
 	}
 
 	// Trust the augmented cert pool in our client

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/iver-wharf/wharf-core/pkg/ginutil"
 	"github.com/iver-wharf/wharf-core/pkg/logger"
+	"github.com/iver-wharf/wharf-core/pkg/logger/consolepretty"
 	"github.com/iver-wharf/wharf-provider-github/docs"
 	"github.com/iver-wharf/wharf-provider-github/internal/httputils"
 
@@ -46,6 +47,8 @@ var log = logger.NewScoped("WHARF-PROVIDER-GITHUB")
 // @contact.email wharf@iver.se
 // @basePath /import
 func main() {
+	logger.AddOutput(logger.LevelDebug, consolepretty.Default)
+
 	var (
 		config Config
 		err    error

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"net/http"
 	"os"
 
@@ -56,7 +55,7 @@ func main() {
 		os.Exit(1)
 	}
 	if config, err = loadConfig(); err != nil {
-		fmt.Println("Failed to read config:", err)
+		log.Error().WithError(err).Message("Failed to read config.")
 		os.Exit(1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -65,7 +65,6 @@ func main() {
 	if config.CA.CertsFile != "" {
 		client, err := httputils.NewClientWithCerts(config.CA.CertsFile)
 		if err != nil {
-			fmt.Println("Failed to get net/http.Client with certs:", err)
 			log.Error().WithError(err).Message("Failed to get net/http.Client with certs.")
 			os.Exit(1)
 		}

--- a/main.go
+++ b/main.go
@@ -92,7 +92,13 @@ func main() {
 	r.GET("/import/github/version", getVersionHandler)
 	r.GET("/import/github/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
-	_ = r.Run(config.HTTP.BindAddress)
+	if err := r.Run(config.HTTP.BindAddress); err != nil {
+		log.Error().
+			WithError(err).
+			WithString("address", config.HTTP.BindAddress).
+			Message("Failed to start web server.")
+		os.Exit(2)
+	}
 }
 
 func runPingHandler(c *gin.Context) {


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Updated to wharf-core v1.1.0, which includes new logging format by default.

- Updated swaggo/swag to v1.7.1, which no longer depends on alecthomas/template but instead the stdlib text/template. (https://github.com/swaggo/swag/releases/tag/v1.7.1)

- Added logging on HTTP server address binding error

## Motivation

Keeping the projects up to date with out own packages
