### PR TITLE
Fixed AllowAllOrigins doc comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   `github.com/iver-wharf/wharf-core/pkg/config` together with new config models
   for configuring wharf-provider-github. See `config.go` or the reference
   documentation on the `Config` type for information on how to configure
-  wharf-provider-github. (#19)
+  wharf-provider-github. (#19, #29)
 
 - Added config for setting bind address and port. (#14, #19)
 

--- a/config.go
+++ b/config.go
@@ -60,7 +60,9 @@ type HTTPConfig struct {
 
 // CORSConfig holds settings for the HTTP server's CORS settings.
 type CORSConfig struct {
-	// AllowAllOrigins enables all
+	// AllowAllOrigins enables CORS and allows all hostnames and URLs in the
+	// HTTP request origins when set to true. Practically speaking, this
+	// results in the HTTP header "Access-Control-Allow-Origin" set to "*".
 	//
 	// For backward compatibility, that may be removed in the next major release
 	// (v3.0.0), the environment variable ALLOW_CORS, which was added in v0.6.0,


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

Comment seems to have ended mid-sentence. I completed it based on the discussion over at https://github.com/iver-wharf/wharf-provider-gitlab/pull/23#pullrequestreview-736934503

## Motivation

Keeping docs relevant.
