### PR TITLE
Removed UploadURL references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,10 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   - Alpine: 3.14.0 -> 3.14 (#33)
   - Golang: 1.16.5 -> 1.16 (#33)
 
+- Removed `UploadURL` field from the `importBody` struct, and all references to
+  `wharfapi.Provider.UploadURL`, which will be removed in wharf-api v5.0.0 as it
+  did not provide any functionality. (#35)
+
 ## v2.0.0 (2021-07-12)
 
 - BREAKING: Changed Wharf API dependency to v4.1.0. This provider now uses call

--- a/github.go
+++ b/github.go
@@ -75,8 +75,8 @@ func (m githubImporterModule) runGitHubHandler(c *gin.Context) {
 	importer.GithubClient, err = importer.initGithubConnection()
 	if err != nil {
 		ginutil.WriteAPIClientReadError(c, err,
-			fmt.Sprintf("Unable to parse provider url %q or upload url %q",
-				importer.Provider.URL, importer.Provider.UploadURL))
+			fmt.Sprintf("Unable to parse provider url %q",
+				importer.Provider.URL))
 		return
 	}
 
@@ -143,11 +143,9 @@ func (importer githubImporter) getProvider(i importBody, token wharfapi.Token) (
 			err = fmt.Errorf("provider with id %v not found", i.ProviderID)
 		} else if provider.URL != i.URL {
 			err = fmt.Errorf("invalid url in provider %q", provider.URL)
-		} else if provider.UploadURL != i.UploadURL {
-			err = fmt.Errorf("invalid upload url in provider %q", provider.UploadURL)
 		}
 	} else {
-		provider, err = importer.WharfClient.PutProvider(wharfapi.Provider{Name: "github", URL: i.URL, UploadURL: i.UploadURL, TokenID: token.TokenID})
+		provider, err = importer.WharfClient.PutProvider(wharfapi.Provider{Name: "github", URL: i.URL, TokenID: token.TokenID})
 	}
 	log.Debug().
 		WithUint("providerId", provider.ProviderID).
@@ -159,7 +157,7 @@ func (importer githubImporter) getProvider(i importBody, token wharfapi.Token) (
 func (importer githubImporter) initGithubConnection() (*github.Client, error) {
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: importer.Token.Token})
 	tc := oauth2.NewClient(importer.Context, ts)
-	client, err := github.NewEnterpriseClient(importer.Provider.URL, importer.Provider.UploadURL, tc)
+	client, err := github.NewEnterpriseClient(importer.Provider.URL, "", tc)
 	return client, err
 }
 

--- a/main.go
+++ b/main.go
@@ -18,11 +18,10 @@ import (
 
 type importBody struct {
 	// used in refresh only
-	TokenID   uint   `json:"tokenId" example:"0"`
-	Token     string `json:"token" example:"sample token"`
-	User      string `json:"user" example:"sample user name"`
-	URL       string `json:"url" example:"https://api.github.com/"`
-	UploadURL string `json:"uploadUrl" example:""`
+	TokenID uint   `json:"tokenId" example:"0"`
+	Token   string `json:"token" example:"sample token"`
+	User    string `json:"user" example:"sample user name"`
+	URL     string `json:"url" example:"https://api.github.com/"`
 	// used in refresh only
 	ProviderID uint `json:"providerId" example:"0"`
 	// azuredevops, gitlab or github


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

- \[x] Wait for new release of wharf-api, with iver-wharf/wharf-api#82

- \[x] ~Wait for new release of wharf-api-client-go, with iver-wharf/wharf-api-client-go#21.~
EDIT: Doesn't seem like we actually need to wait for this.

## Summary

Removed `UploadURL` field from the `importBody` struct.
Removed any reference to `wharfapi.Provider.UploadURL`.

## Motivation

These fields did not provide any functionality and were thus effectively just bloat.

Required change to be compatible with iver-wharf/wharf-api-client-go#21.

Part of inter-repo change, together with:
- iver-wharf/wharf-api#82
- iver-wharf/wharf-api-client-go#21
- iver-wharf/wharf-provider-gitlab#30
- iver-wharf/wharf-provider-azuredevops#39

--
Closes #32