### PR TITLE
Makefile: only run 'swag init' if needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ build: swag
 	go build .
 	@echo "Built binary found at ./wharf-provider-github or ./wharf-provider-github.exe"
 
+test: swag
+	go test -v ./...
+
 docker:
 	docker build . \
 		--pull \
@@ -26,8 +29,19 @@ docker-run:
 serve: swag
 	go run .
 
-swag:
+swag-force:
 	swag init --parseDependency --parseDepth 2
+
+swag:
+ifeq ("$(wildcard docs/docs.go)","")
+	swag init --parseDependency --parseDepth 2
+else
+ifeq ("$(filter $(MAKECMDGOALS),swag-force)","")
+	@echo "-- Skipping 'swag init' because docs/docs.go exists."
+	@echo "-- Run 'make' with additional target 'swag-force' to always run it."
+endif
+endif
+	@# This comment silences warning "make: Nothing to be done for 'swag'."
 
 deps:
 	cd .. && go get -u github.com/swaggo/swag/cmd/swag@v1.7.1


### PR DESCRIPTION
- \[ ] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Skip `swag init` in Makefile if the `docs/docs.go` file exists
- Added `swag-force` target to Makefile that runs even if the `docs/docs.go` file exists
- Added missing `test` target to Makefile

## Motivation

This makes `make serve`, `make tests`, etc more useful, by only running if needed, as `swag init` takes so much time to run

Based on iver-wharf/wharf-api#84
