### PR TITLE
Updated to wharf-core v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
   from `github.com/iver-wharf/wharf-core/pkg/ginutil`. (#20)
 
 - Changed version of `github.com/iver-wharf/wharf-core` from pre release to
-  v1.2.0. (#19, #28, #30)
+  v1.3.0. (#19, #28, #30, #43)
 
 - Changed version of `github.com/iver-wharf/wharf-api-client-go`
   from v1.3.0 -> v1.3.1. (#31)

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/iver-wharf/wharf-api-client-go v1.3.1
-	github.com/iver-wharf/wharf-core v1.2.0
+	github.com/iver-wharf/wharf-core v1.3.0
 	github.com/json-iterator/go v1.1.11 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -285,8 +285,8 @@ github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod
 github.com/iver-wharf/wharf-api-client-go v1.3.1 h1:R3gol3x1iHT1boZf/J0YqB1ml4SEJEVllZ6rk3gyTPU=
 github.com/iver-wharf/wharf-api-client-go v1.3.1/go.mod h1:nv5UChpadYGVvsHhfSw4ss7cOFoTiAJWejzZ+7/23cg=
 github.com/iver-wharf/wharf-core v1.1.0/go.mod h1:dpYtdL52i17Aue7An6mJL9dICeulBDsGZO/PxZYHgrE=
-github.com/iver-wharf/wharf-core v1.2.0 h1:iwtnBh6XbDyb/Z7pAMZMbXNIFM63fp/qS9DChxQ+ukA=
-github.com/iver-wharf/wharf-core v1.2.0/go.mod h1:dpYtdL52i17Aue7An6mJL9dICeulBDsGZO/PxZYHgrE=
+github.com/iver-wharf/wharf-core v1.3.0 h1:iJqa0JYBkMmJDkBKeErKCpZCa+qa97u5MLMBQ685Jhs=
+github.com/iver-wharf/wharf-core v1.3.0/go.mod h1:dpYtdL52i17Aue7An6mJL9dICeulBDsGZO/PxZYHgrE=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=
 github.com/jackc/chunkreader/v2 v2.0.0/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=
 github.com/jackc/chunkreader/v2 v2.0.1/go.mod h1:odVSm741yZoC3dpHEUXIqA9tQRhFrgOHwnPIn9lDKlk=


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Updated to wharf-core v1.3.0 (https://github.com/iver-wharf/wharf-core/releases/tag/v1.3.0)

## Motivation

Keep the repos dependencies up-to-date
