### PR TITLE
Moved linting to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,13 @@ commit = $(shell git rev-parse HEAD)
 version = latest
 
 ifeq ($(OS),Windows_NT)
-wharf-provider-azuredevops.exe: swag
+wharf-provider-github.exe: swag
 	go build .
-	@echo "Built binary found at ./wharf-provider-azuredevops.exe"
+	@echo "Built binary found at ./wharf-provider-github.exe"
 else
-wharf-provider-azuredevops: swag
+wharf-provider-github: swag
 	go build .
-	@echo "Built binary found at ./wharf-provider-azuredevops"
+	@echo "Built binary found at ./wharf-provider-github"
 endif
 
 install:
@@ -35,20 +35,20 @@ deps:
 docker:
 	docker build . \
 		--pull \
-		-t "quay.io/iver-wharf/wharf-provider-azuredevops:latest" \
-		-t "quay.io/iver-wharf/wharf-provider-azuredevops:$(version)" \
+		-t "quay.io/iver-wharf/wharf-provider-github:latest" \
+		-t "quay.io/iver-wharf/wharf-provider-github:$(version)" \
 		--build-arg BUILD_VERSION="$(version)" \
 		--build-arg BUILD_GIT_COMMIT="$(commit)" \
 		--build-arg BUILD_DATE="$(shell date --iso-8601=seconds)"
 	@echo ""
 	@echo "Push the image by running:"
-	@echo "docker push quay.io/iver-wharf/wharf-provider-azuredevops:latest"
+	@echo "docker push quay.io/iver-wharf/wharf-provider-github:latest"
 ifneq "$(version)" "latest"
-	@echo "docker push quay.io/iver-wharf/wharf-provider-azuredevops:$(version)"
+	@echo "docker push quay.io/iver-wharf/wharf-provider-github:$(version)"
 endif
 
 docker-run:
-	docker run --rm -it quay.io/iver-wharf/wharf-provider-azuredevops:$(version)
+	docker run --rm -it quay.io/iver-wharf/wharf-provider-github:$(version)
 
 serve: swag
 	go run .

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: install check tidy deps \
 	docker docker-run serve swag-force swag \
 	lint lint-md lint-go \
-	lint-fix lint-md-fix
+	lint-fix lint-fix-md lint-fix-go
 
 commit = $(shell git rev-parse HEAD)
 version = latest
@@ -66,3 +66,19 @@ ifeq ("$(filter $(MAKECMDGOALS),swag-force)","")
 endif
 endif
 	@# This comment silences warning "make: Nothing to be done for 'swag'."
+
+lint: lint-md lint-go
+lint-fix: lint-fix-md lint-fix-go
+
+lint-md:
+	npx remark . .github
+
+lint-fix-md:
+	npx remark . .github -o
+
+lint-go:
+	goimports -d $(shell git ls-files "*.go")
+	revive -formatter stylish -config revive.toml ./...
+
+lint-fix-go:
+	goimports -d -w $(shell git ls-files "*.go")

--- a/Makefile
+++ b/Makefile
@@ -54,11 +54,11 @@ serve: swag
 	go run .
 
 swag-force:
-	swag init --parseDependency --parseDepth 1
+	swag init --parseDependency --parseDepth 2
 
 swag:
 ifeq ("$(wildcard docs/docs.go)","")
-	swag init --parseDependency --parseDepth 1
+	swag init --parseDependency --parseDepth 2
 else
 ifeq ("$(filter $(MAKECMDGOALS),swag-force)","")
 	@echo "-- Skipping 'swag init' because docs/docs.go exists."

--- a/README.md
+++ b/README.md
@@ -69,43 +69,25 @@ docker push quay.io/iver-wharf/wharf-provider-github:latest
 docker push quay.io/iver-wharf/wharf-provider-github:v2.0.0
 ```
 
-## Linting Golang
-
-- Requires Node.js (npm) to be installed: <https://nodejs.org/en/download/>
-- Requires Revive to be installed: <https://revive.run/>
-
-```sh
-go get -u github.com/mgechev/revive
-```
-
-```sh
-npm run lint-go
-```
-
-## Linting markdown
-
-- Requires Node.js (npm) to be installed: <https://nodejs.org/en/download/>
-
-```sh
-npm install
-
-npm run lint-md
-
-# Some errors can be fixed automatically. Keep in mind that this updates the
-# files in place.
-npm run lint-md-fix
-```
-
 ## Linting
 
 You can lint all of the above at the same time by running:
 
 ```sh
-npm run lint
+make lint
 
-# Some errors can be fixed automatically. Keep in mind that this updates the
-# files in place.
-npm run lint-fix
+make lint-go # only lint Go code
+make lint-md # only lint Markdown files
+```
+
+Some errors can be fixed automatically. Keep in mind that this updates the
+files in place.
+
+```sh
+make lint-fix
+
+#make lint-fix-go # Go linter does not support fixes
+make lint-fix-md # only lint and fix Markdown files
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ docker push quay.io/iver-wharf/wharf-provider-github:v2.0.0
 
 ## Linting
 
-You can lint all of the above at the same time by running:
-
 ```sh
+make deps # download linting dependencies
+
 make lint
 
 make lint-go # only lint Go code

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ files in place.
 ```sh
 make lint-fix
 
-#make lint-fix-go # Go linter does not support fixes
+make lint-fix-go # only lint and fix Go files
 make lint-fix-md # only lint and fix Markdown files
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,4 @@
 {
-  "scripts": {
-    "lint": "\"$npm_execpath\" run lint-md && \"$npm_execpath\" run lint-go",
-    "lint-fix": "\"$npm_execpath\" run lint-md-fix",
-    "lint-md": "remark . .github",
-    "lint-md-fix": "remark . .github -o",
-    "lint-go": "revive -formatter stylish -config revive.toml ./..."
-  },
   "devDependencies": {
     "remark-cli": "^9.0.0",
     "remark-lint": "^8.0.0",


### PR DESCRIPTION
## Summary

- Added targets to `Makefile` for linting and other utilities like cleaning
- Removed linting from NPM scripts in `package.json`
- Simplified linting docs

## Motivation

Moves focus from relying on NPM for all linting stuff over to Makefile.

Based on https://github.com/iver-wharf/wharf-cmd/pull/31
