### PR TITLE
Changed to import SSH URL instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,12 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 
 - Changed Dockerfile for easier windows building. (#44)
 
+- Fixed usage of `git://` URLs when importing and refreshing projects. Since 
+  January 11, 2022, GitHub disabled `git://` URLs in favor of only `https://`
+  and `ssh://` URLs. (#48)
+
+  Read more here: <https://github.blog/2021-09-01-improving-git-protocol-security-github/>
+
 ## v2.0.0 (2021-07-12)
 
 - BREAKING: Changed Wharf API dependency to v4.1.0. This provider now uses call

--- a/github.go
+++ b/github.go
@@ -216,7 +216,7 @@ func (importer githubImporter) refreshProject(i importBody) error {
 		Description:     repo.GetDescription(),
 		AvatarURL:       *repo.GetOwner().AvatarURL,
 		ProviderID:      importer.Provider.ProviderID,
-		GitURL:          *repo.GitURL}
+		GitURL:          *repo.SSHURL}
 	_, err = importer.WharfClient.UpdateProject(i.ProjectID, projectUpdate)
 	return err
 }
@@ -273,7 +273,7 @@ func (importer githubImporter) createProject(repo *github.Repository) error {
 		Description:     repo.GetDescription(),
 		AvatarURL:       *repo.GetOwner().AvatarURL,
 		ProviderID:      importer.Provider.ProviderID,
-		GitURL:          *repo.GitURL,
+		GitURL:          *repo.SSHURL,
 		RemoteProjectID: strconv.FormatInt(repo.GetID(), 10),
 	}
 


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

- Changed to use the `ssh_url` JSON field instead of `git_url`

## Motivation

Since January 11, 2022, GitHub disabled `git://` URLs: <https://github.blog/2021-09-01-improving-git-protocol-security-github/>

When getting the repository via `GET api.github.com/repos/iver-wharf/wharf-cmd` we receive the following:

```console
$ curl -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/iver-wharf/wharf-cmd"
...
  "updated_at": "2022-01-10T13:33:19Z",
  "pushed_at": "2022-03-23T09:04:34Z",
  "git_url": "git://github.com/iver-wharf/wharf-cmd.git",
  "ssh_url": "git@github.com:iver-wharf/wharf-cmd.git",
  "clone_url": "https://github.com/iver-wharf/wharf-cmd.git",
  "svn_url": "https://github.com/iver-wharf/wharf-cmd",
  "homepage": null,
  "size": 788,
...
```

We only use SSH inside Wharf right now because HTTPS is tedious to work with. Using HTTPS could be a nice migration later as that would use the same token that we already use for the GitHub API access, but wharf-cmd and the Jenkins implementation, together with wharf-api, does not support feeding the credentials in that way.

For now, we stick with only fixing the SSH access that we were using already.
