### PR TITLE
Release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
-## v3.0.0 (WIP)
+## v3.0.0 (2022-03-23)
 
 - BREAKING: Removed support for `github.com/iver-wharf/wharf-api` v4.
   Now requires a minimum of wharf-api v5.0.0. (#45)


### PR DESCRIPTION
- \[x] I've updated the `(WIP)` tag to today's date in `CHANGELOG.md`
- \[x] I've added the `release` label to this PR

## Changes

- BREAKING: Removed support for `github.com/iver-wharf/wharf-api` v4. Now requires a minimum of wharf-api v5.0.0. (#45)

- Added support for `github.com/iver-wharf/wharf-api` v5.0.0. (#45)

- Changed version of `github.com/iver-wharf/wharf-api-client-go` from v1.3.0 -> v2.0.0. (#31, #45)

- Added GitHub's internal project ID when adding project to database. (#45)

- Added support for the TZ environment variable (setting timezones ex. `"Europe/Stockholm"`) through the tzdata package. (#25)

- Added config loading from YAML files using `github.com/iver-wharf/wharf-core/pkg/config` together with new config models for configuring wharf-provider-github. See `config.go` or the reference documentation on the `Config` type for information on how to configure wharf-provider-github. (#19, #29)

- Added config for setting bind address and port. (#14, #19)

  - Environment variable: `WHARF_HTTP_BINDADDRESS`
  - YAML: `http.bindAddress`

- Added config for loading extra certificates bundle, in addition to the system's certificates. (#19)

  - Environment variable: `WHARF_CA_CERTSFILE`
  - YAML: `ca.certsFile`

- Added logging library `github.com/iver-wharf/wharf-core/pkg/logger` instead of `fmt.Println` throughout the repository, as well as the Gin integration from `github.com/iver-wharf/wharf-core/pkg/ginutil`. (#20)

- Changed version of `github.com/iver-wharf/wharf-core` from pre release to v1.3.0. (#19, #28, #30, #43)

- Changed to return IETF RFC-7807 compatible problem responses on failures instead of solely JSON-formatted strings. (#16)

- Added Makefile to simplify building and developing the project locally.  (#24, #26, #27, #28)

- Added logging and custom exit code when app fails to bind the IP address and port. (#28)

- Removed `internal/httputils`, which was moved to `github.com/iver-wharf/wharf-core/pkg/cacertutil`. (#30)

- Changed version of Docker base images, relying on "latest" patch version:

  - Alpine: 3.14.0 -> 3.14 (#33)
  - Golang: 1.16.5 -> 1.16 (#33)

- Removed `UploadURL` field from the `importBody` struct, and all references to `wharfapi.Provider.UploadURL`, which will be removed in wharf-api v5.0.0 as it did not provide any functionality. (#35)

- Changed Dockerfile for easier windows building. (#44)

- Fixed usage of `git://` URLs when importing and refreshing projects. Since January 11, 2022, GitHub disabled `git://` URLs in favor of only `https://` and `ssh://` URLs. (#48)

  Read more here: <https://github.blog/2021-09-01-improving-git-protocol-security-github/>

## Actions after merge

Follow the step-by-step guide found here:
<https://iver-wharf.github.io/#/development/releasing-a-new-version?id=merging-a-release-pr>
