### PR TITLE
Add early return on project refresh for /import/github.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 ## v3.0.1 (WIP)
 
 - Fixed an issue where clicking refresh on a project would incorrectly raise
-  an error. (#51)
+  an error. (#52)
 
 ## v3.0.0 (2022-03-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ This project tries to follow [SemVer 2.0.0](https://semver.org/).
 	https://changelog.md/
 -->
 
+## v3.0.1 (WIP)
+
+- Fixed an issue where clicking refresh on a project would incorrectly raise
+  an error. (#51)
+
 ## v3.0.0 (2022-03-23)
 
 - BREAKING: Removed support for `github.com/iver-wharf/wharf-api` v4.

--- a/github.go
+++ b/github.go
@@ -92,6 +92,9 @@ func (m githubImporterModule) runGitHubHandler(c *gin.Context) {
 				fmt.Sprintf("Unable to refresh project %q with ID %d from GitHub.", i.Project, i.ProjectID))
 			return
 		}
+		// If a refresh is possible the project already exists. Don't create a new project from group/name.
+		c.Status(http.StatusOK)
+		return
 	}
 
 	if i.Project != "" {


### PR DESCRIPTION
- \[x] I've added a new note in the `CHANGELOG.md` file, according to docs:
  https://iver-wharf.github.io/#/development/changelogs/writing-changelogs

## Summary

A post type request body targeting `/import/github` with contents 
```json
{"projectId":2,"url":"https://api.github.com","tokenId":1,"group":"iver-wharf","project":"wharf-api","providerId":1}
```  
Would cause a project refresh to succeed with a failiure message. When the project would get refreshed in [the first if](https://github.com/iver-wharf/wharf-provider-github/blob/bba1216605d232f60d6d5eb91741a232a16d60df/github.go#L87-L113) and would then return a failiure on the create new project condition. This error would get passed forward to the web client.

## Motivation

This resolves and issue describe in https://github.com/iver-wharf/wharf-provider-github/issues/51


Closes https://github.com/iver-wharf/wharf-provider-github/issues/51